### PR TITLE
Add c99 CFLAG option for x86_64-linux

### DIFF
--- a/src/main/native/jgskit.mak
+++ b/src/main/native/jgskit.mak
@@ -32,7 +32,7 @@ AIX_LIBPATH = /usr/lib:/lib
 
 ifeq ($(PLATFORM),x86-linux64)
       PLAT=xa
-      CFLAGS+= -DLINUX -pedantic -Werror -Wall -fstack-protector
+      CFLAGS+= -DLINUX -std=gnu99 -pedantic -Werror -Wall -fstack-protector
       LDFLAGS+= -m64
       IS64SYSTEM=64
       OSINCLUDEDIR=linux


### PR DESCRIPTION
Use the `-std=gnu99` flag to ensure that the `C99` standard is used when compiling the C files in `x86_64-linux`. This avoids warnings that lead to errors due to the `-Werror` flag that is already present.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)