### PR TITLE
Add notices file for openjceplus module

### DIFF
--- a/NOTICES.md
+++ b/NOTICES.md
@@ -11,7 +11,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
 Apache-2.0. See included module OPENJCEPLUS_LICENCE file for details.
 
 As part of a FIPS 140-3 technology preview capability, this Semeru Runtimes distribution includes a modified OpenSSL 1.1.1 toolkit binary that is currently undergoing FIPS 140-3 certification testing at the U.S. National Institute of Standards and Technology (NIST). Because this toolkit version was built and submitted to NIST before we contributed its code to an open source project (now at https://github.com/IBM/OpenCryptographyKitC), the toolkit binary included in this release contains strings that reference an IBM license. These strings have been removed from the open-source version of the toolkit.
-This notice supersedes the IBM license expressed in the binary itself. The toolkit binary for use with the FIPS 140-3 technology preview capability uses the OpenSSL 1.1.1 license (see OpenSSL third-party content referenced below) as well as the Apache License 2.0 (see OPENJCEPLUS_LICENCE).
+
+This notice supersedes the IBM license expressed in the binary itself. The toolkit binary for use with the FIPS 140-3 technology preview capability license terms are found in https://github.com/IBM/OpenCryptographyKitC/blob/main/LICENSE.
 
 ### Cryptography
 
@@ -23,11 +24,11 @@ possession, or use, and re-export of encryption software, to see if this is perm
 
 This module leverages the following third party content.
 
-OpenSSL (1.1.1)
+OpenJCEPlus
 
-* License: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/LICENSE
-* Project: https://www.openssl.org/
-* Source: https://github.com/IBM/OpenCryptographyKitC/tree/main/openssl_source based upon https://github.com/openssl/openssl
+* License: https://github.com/IBM/OpenJCEPlus/blob/main/LICENSE
+* Project: https://github.com/IBM/OpenJCEPlus
+* Source: https://github.com/IBM/OpenJCEPlus
 
 OpenCryptographyKitC
 

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -1,0 +1,36 @@
+# Notices for OpenJCEPlus Module
+
+* Project home: https://github.com/IBM/OpenJCEPlus
+
+## Trademarks
+
+Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.
+
+## Applicable Licenses
+
+Apache-2.0. See included module OPENJCEPLUS_LICENCE file for details.
+
+As part of a FIPS 140-3 technology preview capability, this Semeru Runtimes distribution includes a modified OpenSSL 1.1.1 toolkit binary that is currently undergoing FIPS 140-3 certification testing at the U.S. National Institute of Standards and Technology (NIST). Because this toolkit version was built and submitted to NIST before we contributed its code to an open source project (now at https://github.com/IBM/OpenCryptographyKitC), the toolkit binary included in this release contains strings that reference an IBM license. These strings have been removed from the open-source version of the toolkit.
+This notice supersedes the IBM license expressed in the binary itself. The toolkit binary for use with the FIPS 140-3 technology preview capability uses the OpenSSL 1.1.1 license (see OpenSSL third-party content referenced below) as well as the Apache License 2.0 (see OPENJCEPLUS_LICENCE).
+
+### Cryptography
+
+Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to
+another country, of encryption software. BEFORE using any encryption software, please check the country's laws, regulations and policies concerning the import,
+possession, or use, and re-export of encryption software, to see if this is permitted.
+
+## Third-party Content
+
+This module leverages the following third party content.
+
+OpenSSL (1.1.1)
+
+* License: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/LICENSE
+* Project: https://www.openssl.org/
+* Source: https://github.com/IBM/OpenCryptographyKitC/tree/main/openssl_source based upon https://github.com/openssl/openssl
+
+OpenCryptographyKitC
+
+* License: https://github.com/IBM/OpenCryptographyKitC/blob/main/LICENSE
+* Project: https://github.com/IBM/OpenCryptographyKitC
+* Source: https://github.com/IBM/OpenCryptographyKitC

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -10,9 +10,13 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
 
 Apache-2.0. See included module OPENJCEPLUS_LICENCE file for details.
 
-As part of a FIPS 140-3 technology preview capability, this Semeru Runtimes distribution includes a modified OpenSSL 1.1.1 toolkit binary that is currently undergoing FIPS 140-3 certification testing at the U.S. National Institute of Standards and Technology (NIST). Because this toolkit version was built and submitted to NIST before we contributed its code to an open source project (now at https://github.com/IBM/OpenCryptographyKitC), the toolkit binary included in this release contains strings that reference an IBM license. These strings have been removed from the open-source version of the toolkit.
+As part of a FIPS 140-3 technology preview capability, this Semeru Runtimes distribution includes a modified OpenSSL 1.1.1 toolkit binary that is currently
+undergoing FIPS 140-3 certification testing at the U.S. National Institute of Standards and Technology (NIST). Because this toolkit version was built and
+submitted to NIST before we contributed its code to an open source project (now at https://github.com/IBM/OpenCryptographyKitC), the toolkit binary included in
+this release contains strings that reference an IBM license. These strings have been removed from the open-source version of the toolkit.
 
-This notice supersedes the IBM license expressed in the binary itself. The toolkit binary for use with the FIPS 140-3 technology preview capability license terms are found in https://github.com/IBM/OpenCryptographyKitC/blob/main/LICENSE.
+This notice supersedes the IBM license expressed in the binary itself. The toolkit binary for use with the FIPS 140-3 technology preview capability license
+terms are found in https://github.com/IBM/OpenCryptographyKitC/blob/main/LICENSE.
 
 ### Cryptography
 

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -13,7 +13,8 @@ Apache-2.0. See included module OPENJCEPLUS_LICENCE file for details.
 As part of a FIPS 140-3 technology preview capability, this Semeru Runtimes distribution includes a modified OpenSSL 1.1.1 toolkit binary that is currently
 undergoing FIPS 140-3 certification testing at the U.S. National Institute of Standards and Technology (NIST). Because this toolkit version was built and
 submitted to NIST before we contributed its code to an open source project (now at https://github.com/IBM/OpenCryptographyKitC), the toolkit binary included in
-this release contains strings that reference an IBM license. These strings have been removed from the open-source version of the toolkit.
+this release contains strings that reference an IBM license. These strings have been removed from the open-source version of the toolkit in addition to other
+minor updates.
 
 This notice supersedes the IBM license expressed in the binary itself. The toolkit binary for use with the FIPS 140-3 technology preview capability license
 terms are found in https://github.com/IBM/OpenCryptographyKitC/blob/main/LICENSE.


### PR DESCRIPTION
The openjceplus module must document dependencies.

The openjceplus module must provide a note concerning the shipment of GSKIT and its implied license within the binary files being bundled.